### PR TITLE
Add App Folder Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ return FutureBuilder(
           final success = await onedrive.connect(context);
           if (success) {
             // Download files
-            final txtBytes = await onedrive.pull("/xxx/xxx.txt");
+            final response = await onedrive.pull("/xxx/xxx.txt");
             // Upload files
-            await onedrive.push(txtBytes!, "/xxx/xxx.txt");
+            await onedrive.push(response.bodyBytes!, "/xxx/xxx.txt");
           }
         },
       );

--- a/example/examples.dart
+++ b/example/examples.dart
@@ -24,9 +24,9 @@ FutureBuilder buildConnectButton(BuildContext context) {
             final success = await onedrive.connect(context);
             if (success) {
               // Download files
-              final txtBytes = await onedrive.pull("/xxx/xxx.txt");
+              final response = await onedrive.pull("/xxx/xxx.txt");
               // Upload files
-              await onedrive.push(txtBytes!, "/xxx/xxx.txt");
+              await onedrive.push(response.bodyBytes!, "/xxx/xxx.txt");
             }
           },
         );

--- a/lib/onedrive_response.dart
+++ b/lib/onedrive_response.dart
@@ -1,0 +1,28 @@
+import 'dart:typed_data';
+
+class OneDriveResponse {
+  final int? statusCode;
+  final String? body;
+  final String? message;
+  final bool isSuccess;
+  final Uint8List? bodyBytes;
+
+  OneDriveResponse({
+    this.statusCode,
+    this.body,
+    this.message,
+    this.bodyBytes,
+    this.isSuccess = false
+  });
+
+  @override
+  String toString() {
+    return "OneDriveResponse("
+        "statusCode: $statusCode, "
+        "body: $body, "
+        "bodyBytes: $bodyBytes, "
+        "message: $message, "
+        "isSuccess: $isSuccess"
+      ")";
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,14 +5,14 @@ homepage: https://github.com/Lukiya/flutter_onedrive
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.17.0 <3.7.12"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_secure_storage: '>=6.0.0'
-  http: '>=0.13.6'
-  oauth_webauth: '>=4.0.0'
+  flutter_secure_storage: ^8.0.0
+  http: ^0.13.0
+  oauth_webauth: ^4.0.0+14
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I have added [App Folder](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/concepts/special-folders-appfolder?view=odsp-graph-online) Feature.

All this changes has been tested on my personal app.

In this commit I also added some changes that I believe it is important, like the constraints on pubspec version. On lower Flutter SDKs, this library will break, as I experienced.

There is also error handling using OneDriveResponse class.

Let me know what you think.